### PR TITLE
Correction for https://github.com/home-assistant/core/issues/125260 via an injection of httpx_client from homeassistant

### DIFF
--- a/example.py
+++ b/example.py
@@ -28,6 +28,7 @@ async def main():
     await client.get_allmetrics()
     print(client.metrics)
 
+    await client.close()
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "netdata"
-version = "1.2.0"
+version = "1.3.0"
 description = "Python API for interacting with Netdata"
 authors = ["Fabian Affolter <mail@fabian-affolter.ch>"]
 license = "MIT"


### PR DESCRIPTION
Hi @fabaff ,
I propose you this small evolution in order to resolve the issue https://github.com/home-assistant/core/issues/125260  in homeassistant that detects event_loop warning in used API for ssl context object (cf : https://developers.home-assistant.io/docs/asyncio_blocking_operations/#load_default_certs).
After digging how other integrations use httpx library, I found that the injection of the client from the core is the correct way of doing it.

It works well in latest homeassistant core on my pc.

After, you release the 1.3.0 version of netdata library, the small correction in homeassistant will be to upgrade netdata dependency and to inject the client via this line of code : `netdata = NetdataData(Netdata(host, port=port, timeout=20.0, httpx_client=get_async_client(hass)))`

I can do the PR on homeassistant core if you want.

If ou have any question, do not hesitate to ask me.
